### PR TITLE
0.0.21

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,6 +23,7 @@
 - `/` -> `Home`
 - `/play` -> `Play` (gameplay)
 - `/ayuda` -> `Help`
+- `/changelog/:version` -> `Changelog`
 - `/settings` -> `Profile`
 - `/profile` -> `Profile` (legacy alias)
 - `/scoreboard` -> `Scoreboard`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2026-05-04
+
+### Branch `0.0.21`
+
+- Bumped package version to `0.0.21`.
+- Added a dedicated changelog page route (`/changelog/:version`) and wired it into app routing.
+- Moved changelog content to a typed JSON source (`src/layouts/View/changelog.json`) with entries keyed by `version` and localized by `language` (`en`/`es`), plus helper resolvers/history derivation in `src/layouts/View/changelog.ts`.
+- Simplified the version-update dialog flow: release announcement copy, linkable version history, and direct CTA to open the current changelog page.
+- Added a full changelog view with release metadata, per-version navigation links, not-found fallback, and a two-column version-history grid.
+- Introduced reusable `Switcher` and `SwitcherField` components and replaced checkbox toggles in Profile Settings and Play Settings Drawer with the new switch UI.
+- Hardened Switcher typing/accessibility by explicitly supporting common input props and ARIA attributes through the component API.
+- Fixed manual tile selection editing so letter insertion in manual mode now advances the active tile index after writing.
+- Fixed manual-mode backspace behavior so it clears the selected tile and moves the cursor left, allowing consecutive deletions.
+- Fixed selected-index deletion behavior so remaining letters no longer shift left unexpectedly (`removeLetterAt` now clears in-place and trims trailing blanks).
+- Fixed Profile page bottom spacing to avoid footer overlap by adding safe-area aware bottom padding.
+
 ## 2026-04-29
 
 ### Branch `0.0.20`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wordle",
   "private": false,
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "scripts": {
     "lint": "npm run lint-typecheck && npm run lint-eslint && npm run lint-prettier && npm run lint-depcheck",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -161,6 +161,7 @@ const preloadAppRoutes = async () => {
     import("@views/GameModes/Zen"),
     import("@views/GameModes/Lightning"),
     import("@views/GameModes/Daily"),
+    import("@views/Changelog"),
     import("@views/Help"),
     import("@views/Scoreboard"),
     import("@views/Profile"),

--- a/src/components/Switcher/Switcher.test.tsx
+++ b/src/components/Switcher/Switcher.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Switcher from "./Switcher";
+
+afterEach(cleanup);
+
+describe("Switcher", () => {
+  it("renders as checkbox and toggles through onChange", () => {
+    const onChange = vi.fn();
+
+    render(
+      <>
+        <label htmlFor="switcher-test">Manual tile selection</label>
+        <Switcher id="switcher-test" checked={false} onChange={onChange} />
+      </>,
+    );
+
+    const input = screen.getByRole("checkbox", {
+      name: "Manual tile selection",
+    }) as HTMLInputElement;
+    expect(input.checked).toBe(false);
+
+    fireEvent.click(input);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles when clicking the visible switch track", () => {
+    const onChange = vi.fn();
+    render(
+      <Switcher id="switcher-track" checked={false} onChange={onChange} />,
+    );
+
+    const input = screen.getByRole("checkbox") as HTMLInputElement;
+    const track = input.nextElementSibling;
+    expect(track).toBeTruthy();
+
+    fireEvent.click(track as HTMLElement);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards disabled state", () => {
+    render(
+      <>
+        <label htmlFor="switcher-disabled">Sound enabled</label>
+        <Switcher id="switcher-disabled" checked disabled />
+      </>,
+    );
+
+    const input = screen.getByRole("checkbox", {
+      name: "Sound enabled",
+    }) as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+  });
+});

--- a/src/components/Switcher/Switcher.tsx
+++ b/src/components/Switcher/Switcher.tsx
@@ -1,10 +1,22 @@
 import type { SwitcherProps } from "./types";
 
 const Switcher = ({
+  id,
+  name,
   className,
   checked,
   disabled,
-  ...props
+  required,
+  autoFocus,
+  tabIndex,
+  onChange,
+  onBlur,
+  onFocus,
+  onKeyDown,
+  onClick,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
+  "aria-describedby": ariaDescribedBy,
 }: SwitcherProps) => {
   const wrapperClassName = [
     "relative inline-flex h-5 w-10 shrink-0 items-center",
@@ -21,13 +33,25 @@ const Switcher = ({
     .join(" ");
 
   return (
-    <span className={wrapperClassName}>
+    <label className={wrapperClassName}>
       <input
         type="checkbox"
+        id={id}
+        name={name}
         checked={checked}
         disabled={disabled}
+        required={required}
+        autoFocus={autoFocus}
+        tabIndex={tabIndex}
+        onChange={onChange}
+        onBlur={onBlur}
+        onFocus={onFocus}
+        onKeyDown={onKeyDown}
+        onClick={onClick}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
         className={inputClassName}
-        {...props}
       />
       <span
         aria-hidden="true"
@@ -37,7 +61,7 @@ const Switcher = ({
         aria-hidden="true"
         className="pointer-events-none absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform duration-200 peer-checked:translate-x-5 dark:bg-neutral-100"
       />
-    </span>
+    </label>
   );
 };
 

--- a/src/components/Switcher/Switcher.tsx
+++ b/src/components/Switcher/Switcher.tsx
@@ -1,0 +1,44 @@
+import type { SwitcherProps } from "./types";
+
+const Switcher = ({
+  className,
+  checked,
+  disabled,
+  ...props
+}: SwitcherProps) => {
+  const wrapperClassName = [
+    "relative inline-flex h-5 w-10 shrink-0 items-center",
+    disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const inputClassName = [
+    "peer absolute inset-0 m-0 h-full w-full opacity-0",
+    disabled ? "cursor-not-allowed" : "cursor-pointer",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <span className={wrapperClassName}>
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        className={inputClassName}
+        {...props}
+      />
+      <span
+        aria-hidden="true"
+        className="h-full w-full rounded-full border border-neutral-400 bg-neutral-200 transition-colors duration-200 dark:border-neutral-600 dark:bg-neutral-700 peer-checked:border-primary peer-checked:bg-primary peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-primary/50 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-neutral-100 dark:peer-focus-visible:ring-offset-neutral-900"
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform duration-200 peer-checked:translate-x-5 dark:bg-neutral-100"
+      />
+    </span>
+  );
+};
+
+export default Switcher;

--- a/src/components/Switcher/SwitcherField.test.tsx
+++ b/src/components/Switcher/SwitcherField.test.tsx
@@ -1,0 +1,39 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import SwitcherField from "./SwitcherField";
+
+afterEach(cleanup);
+
+describe("SwitcherField", () => {
+  it("renders label and description", () => {
+    render(
+      <SwitcherField
+        id="switcher-field-test"
+        checked={false}
+        onChange={vi.fn()}
+        label="Manual tile selection"
+        description="Enable manual selection of board tiles."
+      />,
+    );
+
+    expect(screen.getByText("Manual tile selection")).toBeTruthy();
+    expect(
+      screen.getByText("Enable manual selection of board tiles."),
+    ).toBeTruthy();
+  });
+
+  it("toggles from label click", () => {
+    const onChange = vi.fn();
+    render(
+      <SwitcherField
+        id="switcher-field-toggle"
+        checked={false}
+        onChange={onChange}
+        label="Sound"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Sound"));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Switcher/SwitcherField.tsx
+++ b/src/components/Switcher/SwitcherField.tsx
@@ -1,0 +1,33 @@
+import Switcher from "./Switcher";
+import type { SwitcherFieldProps } from "./types";
+
+const SwitcherField = ({
+  id,
+  label,
+  description,
+  className,
+  switcherClassName = "mt-1",
+  labelClassName = "profile-field-label",
+  descriptionClassName = "text-xs text-neutral-600 dark:text-neutral-300",
+  ...switcherProps
+}: SwitcherFieldProps) => {
+  const fieldClassName = ["flex items-start gap-3", className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={fieldClassName}>
+      <Switcher id={id} className={switcherClassName} {...switcherProps} />
+      <div>
+        <label htmlFor={id} className={labelClassName}>
+          {label}
+        </label>
+        {description ? (
+          <p className={descriptionClassName}>{description}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default SwitcherField;

--- a/src/components/Switcher/SwitcherField.tsx
+++ b/src/components/Switcher/SwitcherField.tsx
@@ -3,13 +3,26 @@ import type { SwitcherFieldProps } from "./types";
 
 const SwitcherField = ({
   id,
+  name,
+  checked,
+  disabled,
+  required,
+  autoFocus,
+  tabIndex,
+  onChange,
+  onBlur,
+  onFocus,
+  onKeyDown,
+  onClick,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
+  "aria-describedby": ariaDescribedBy,
   label,
   description,
   className,
   switcherClassName = "mt-1",
   labelClassName = "profile-field-label",
   descriptionClassName = "text-xs text-neutral-600 dark:text-neutral-300",
-  ...switcherProps
 }: SwitcherFieldProps) => {
   const fieldClassName = ["flex items-start gap-3", className]
     .filter(Boolean)
@@ -17,7 +30,24 @@ const SwitcherField = ({
 
   return (
     <div className={fieldClassName}>
-      <Switcher id={id} className={switcherClassName} {...switcherProps} />
+      <Switcher
+        id={id}
+        name={name}
+        checked={checked}
+        disabled={disabled}
+        required={required}
+        autoFocus={autoFocus}
+        tabIndex={tabIndex}
+        onChange={onChange}
+        onBlur={onBlur}
+        onFocus={onFocus}
+        onKeyDown={onKeyDown}
+        onClick={onClick}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        className={switcherClassName}
+      />
       <div>
         <label htmlFor={id} className={labelClassName}>
           {label}

--- a/src/components/Switcher/index.ts
+++ b/src/components/Switcher/index.ts
@@ -1,0 +1,4 @@
+import Switcher from "./Switcher";
+import SwitcherField from "./SwitcherField";
+
+export { Switcher, SwitcherField };

--- a/src/components/Switcher/types.ts
+++ b/src/components/Switcher/types.ts
@@ -1,8 +1,20 @@
-export type SwitcherProps = Omit<
-  React.InputHTMLAttributes<HTMLInputElement>,
-  "type"
-> & {
+export type SwitcherProps = {
+  id?: string;
+  name?: string;
   checked: boolean;
+  disabled?: boolean;
+  required?: boolean;
+  autoFocus?: boolean;
+  tabIndex?: number;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  onBlur?: React.FocusEventHandler<HTMLInputElement>;
+  onFocus?: React.FocusEventHandler<HTMLInputElement>;
+  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
+  onClick?: React.MouseEventHandler<HTMLInputElement>;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+  "aria-describedby"?: string;
+  className?: string;
 };
 
 export type SwitcherFieldProps = Omit<SwitcherProps, "id" | "className"> & {

--- a/src/components/Switcher/types.ts
+++ b/src/components/Switcher/types.ts
@@ -1,0 +1,16 @@
+export type SwitcherProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "type"
+> & {
+  checked: boolean;
+};
+
+export type SwitcherFieldProps = Omit<SwitcherProps, "id" | "className"> & {
+  id: string;
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  className?: string;
+  switcherClassName?: string;
+  labelClassName?: string;
+  descriptionClassName?: string;
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,7 @@ import { Fire, FireStreak } from "./FireStreak";
 import { SplashScreen } from "./SplashScreen";
 import { Alert } from "./Alert";
 import { CountdownBadge } from "./CountdownBadge";
+import { Switcher, SwitcherField } from "./Switcher";
 export {
   Button,
   ErrorBoundary,
@@ -13,6 +14,8 @@ export {
   SplashScreen,
   Alert,
   CountdownBadge,
+  Switcher,
+  SwitcherField,
 };
 
 export * from "./Dialogs";

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -7,6 +7,7 @@ export const ROUTES = {
   ZEN: "/zen",
   LIGHTING: "/relampago",
   DAILY: "/palabra-diaria",
+  CHANGELOG: "/changelog/:version",
   HELP: "/ayuda",
   SETTINGS: "/ajustes",
   PROFILE: "/perfil",
@@ -47,3 +48,6 @@ export const getHelpRoute = (modeId?: string | null): string => {
 
   return `${ROUTES.HELP}?${searchParams.toString()}`;
 };
+
+export const getChangelogRoute = (version: string): string =>
+  ROUTES.CHANGELOG.replace(":version", encodeURIComponent(version));

--- a/src/domain/wordle/state.test.ts
+++ b/src/domain/wordle/state.test.ts
@@ -218,9 +218,20 @@ describe("setLetterAt", () => {
 });
 
 describe("removeLetterAt", () => {
-  it("removes the letter at the provided index", () => {
+  it("clears the letter at the provided index without shifting others", () => {
     const next = removeLetterAt(makeState({ current: "CRANE" }), 2);
-    expect(next.current).toBe("CRNE");
+    expect(next.current).toBe("CR NE");
+  });
+
+  it("trims trailing empty cells after clearing the last letter", () => {
+    const next = removeLetterAt(makeState({ current: "CRA" }), 2);
+    expect(next.current).toBe("CR");
+  });
+
+  it("does nothing when the selected cell is already empty", () => {
+    const state = makeState({ current: "C A" });
+    const next = removeLetterAt(state, 1);
+    expect(next.current).toBe("C A");
   });
 
   it("ignores out-of-range indexes", () => {

--- a/src/domain/wordle/state.ts
+++ b/src/domain/wordle/state.ts
@@ -253,9 +253,11 @@ export const removeLetterAt = (
     return state;
   }
 
-  const nextCurrent =
-    (state.current.slice(0, index) + " " + state.current.slice(index + 1))
-      .trimEnd();
+  const nextCurrent = (
+    state.current.slice(0, index) +
+    " " +
+    state.current.slice(index + 1)
+  ).trimEnd();
 
   return {
     ...state,

--- a/src/domain/wordle/state.ts
+++ b/src/domain/wordle/state.ts
@@ -248,9 +248,18 @@ export const removeLetterAt = (
     return state;
   }
 
+  const letterAtIndex = state.current[index];
+  if (!letterAtIndex || letterAtIndex.trim() === "") {
+    return state;
+  }
+
+  const nextCurrent =
+    (state.current.slice(0, index) + " " + state.current.slice(index + 1))
+      .trimEnd();
+
   return {
     ...state,
-    current: state.current.slice(0, index) + state.current.slice(index + 1),
+    current: nextCurrent,
   };
 };
 

--- a/src/hooks/useWordle/useWordle.test.tsx
+++ b/src/hooks/useWordle/useWordle.test.tsx
@@ -389,7 +389,7 @@ describe("useWordle dictionary query integration", () => {
     expect(result.current.current).toBe("Ñ");
   });
 
-  it("removes the selected letter with backspace in manual mode", () => {
+  it("clears the selected letter with backspace in manual mode without shifting", () => {
     const loadWords = vi.fn().mockReturnValue(new Promise<string[]>(() => {}));
     const queryClient = createTestQueryClient();
     const wrapper = createHookWrapper(
@@ -421,7 +421,8 @@ describe("useWordle dictionary query integration", () => {
     act(() => {
       result.current.handleKey("BACKSPACE");
     });
-    expect(result.current.current).toBe("B");
+    expect(result.current.current).toBe(" B");
+    expect(result.current.current[1]).toBe("B");
     expect(result.current.activeTileIndex).toBe(0);
   });
 

--- a/src/hooks/useWordle/useWordle.test.tsx
+++ b/src/hooks/useWordle/useWordle.test.tsx
@@ -237,7 +237,7 @@ describe("useWordle dictionary query integration", () => {
     dialog.remove();
   });
 
-  it("supports manual tile selection without automatic cursor advance", () => {
+  it("supports manual tile selection with automatic cursor advance", () => {
     const loadWords = vi.fn().mockReturnValue(new Promise<string[]>(() => {}));
     const queryClient = createTestQueryClient();
     const wrapper = createHookWrapper(
@@ -258,13 +258,13 @@ describe("useWordle dictionary query integration", () => {
       result.current.handleKey("A");
     });
     expect(result.current.current).toBe("A");
-    expect(result.current.activeTileIndex).toBe(0);
+    expect(result.current.activeTileIndex).toBe(1);
 
     act(() => {
       result.current.handleKey("B");
     });
-    expect(result.current.current).toBe("B");
-    expect(result.current.activeTileIndex).toBe(0);
+    expect(result.current.current).toBe("AB");
+    expect(result.current.activeTileIndex).toBe(2);
 
     act(() => {
       result.current.selectActiveTile(1);
@@ -272,8 +272,8 @@ describe("useWordle dictionary query integration", () => {
     act(() => {
       result.current.handleKey("C");
     });
-    expect(result.current.current).toBe("BC");
-    expect(result.current.activeTileIndex).toBe(1);
+    expect(result.current.current).toBe("AC");
+    expect(result.current.activeTileIndex).toBe(2);
   });
 
   it("respects custom round config limits for row length", () => {
@@ -389,7 +389,7 @@ describe("useWordle dictionary query integration", () => {
     expect(result.current.current).toBe("Ñ");
   });
 
-  it("clears the selected letter with backspace in manual mode without shifting", () => {
+  it("clears the selected letter with backspace in manual mode and moves cursor left", () => {
     const loadWords = vi.fn().mockReturnValue(new Promise<string[]>(() => {}));
     const queryClient = createTestQueryClient();
     const wrapper = createHookWrapper(
@@ -416,13 +416,18 @@ describe("useWordle dictionary query integration", () => {
     expect(result.current.current).toBe("AB");
 
     act(() => {
-      result.current.selectActiveTile(0);
+      result.current.selectActiveTile(1);
     });
     act(() => {
       result.current.handleKey("BACKSPACE");
     });
-    expect(result.current.current).toBe(" B");
-    expect(result.current.current[1]).toBe("B");
+    expect(result.current.current).toBe("A");
+    expect(result.current.activeTileIndex).toBe(0);
+
+    act(() => {
+      result.current.handleKey("BACKSPACE");
+    });
+    expect(result.current.current).toBe("");
     expect(result.current.activeTileIndex).toBe(0);
   });
 
@@ -451,25 +456,25 @@ describe("useWordle dictionary query integration", () => {
       result.current.handleKey("B");
     });
     expect(result.current.current).toBe("AB");
-    expect(result.current.activeTileIndex).toBe(1);
+    expect(result.current.activeTileIndex).toBe(2);
 
     act(() => {
       result.current.handleKey("ARROWLEFT");
     });
-    expect(result.current.activeTileIndex).toBe(0);
-
-    act(() => {
-      result.current.handleKey("ARROWRIGHT");
-    });
     expect(result.current.activeTileIndex).toBe(1);
 
     act(() => {
       result.current.handleKey("ARROWRIGHT");
     });
+    expect(result.current.activeTileIndex).toBe(2);
+
     act(() => {
       result.current.handleKey("ARROWRIGHT");
     });
-    expect(result.current.activeTileIndex).toBe(3);
+    act(() => {
+      result.current.handleKey("ARROWRIGHT");
+    });
+    expect(result.current.activeTileIndex).toBe(4);
   });
 
   it("plays keyboard sounds when adding and deleting letters", () => {

--- a/src/hooks/useWordle/useWordle.ts
+++ b/src/hooks/useWordle/useWordle.ts
@@ -49,7 +49,6 @@ import {
   isEditableKeyboardTarget,
   hasVisibleModalDialog,
   markStartAnimationAsSeen,
-  shiftHintStatusesLeftFromIndex,
   shouldAnimateKeyboardEntryOnSession,
   shouldAnimateOnFirstSessionView,
 } from "./utils";
@@ -494,9 +493,15 @@ export default function useWordle(options: UseWordleOptions = {}) {
       }
 
       setGameStateWithPersistence((prev) => removeLetterAt(prev, removedIndex));
-      setActiveRowHintStatuses((previous) =>
-        shiftHintStatusesLeftFromIndex(previous, removedIndex),
-      );
+      setActiveRowHintStatuses((previous) => {
+        if (!(removedIndex in previous)) {
+          return previous;
+        }
+
+        const next = { ...previous };
+        delete next[removedIndex];
+        return next;
+      });
       setHintRevealTileIndex((previous) => {
         if (previous === null) {
           return null;
@@ -504,10 +509,6 @@ export default function useWordle(options: UseWordleOptions = {}) {
 
         if (previous === removedIndex) {
           return null;
-        }
-
-        if (previous > removedIndex) {
-          return previous - 1;
         }
 
         return previous;

--- a/src/hooks/useWordle/useWordle.ts
+++ b/src/hooks/useWordle/useWordle.ts
@@ -513,6 +513,7 @@ export default function useWordle(options: UseWordleOptions = {}) {
 
         return previous;
       });
+      setActiveTileIndex(Math.max(removedIndex - 1, 0));
       playSound("letter_delete");
       return;
     }
@@ -577,11 +578,13 @@ export default function useWordle(options: UseWordleOptions = {}) {
       setHintRevealTileIndex((previous) =>
         previous === targetIndex ? null : previous,
       );
+      setActiveTileIndex(Math.min(targetIndex + 1, maxSelectableTileIndex));
       playSound("letter_put");
     },
     [
       current.length,
       manualTileSelection,
+      maxSelectableTileIndex,
       playSound,
       resolvedRoundConfig,
       selectedTileIndex,

--- a/src/hooks/useWordle/utils.ts
+++ b/src/hooks/useWordle/utils.ts
@@ -2,7 +2,6 @@ import {
   WORDLE_START_ANIMATION_SESSION_KEY,
   WORDLE_KEYBOARD_ENTRY_ANIMATION_SESSION_KEY,
 } from "@domain/wordle";
-import type { HintTileStatus } from "./types";
 
 export const hasSeenStartAnimationInSession = (): boolean => {
   if (typeof window === "undefined") {
@@ -153,34 +152,4 @@ export const getFirstEmptyTileIndex = (
   }
 
   return null;
-};
-
-export const shiftHintStatusesLeftFromIndex = (
-  previous: Record<number, HintTileStatus>,
-  removedIndex: number,
-): Record<number, HintTileStatus> => {
-  let changed = false;
-  const next: Record<number, HintTileStatus> = {};
-
-  for (const [rawIndex, status] of Object.entries(previous)) {
-    const index = Number(rawIndex);
-    if (!Number.isInteger(index)) {
-      continue;
-    }
-
-    if (index === removedIndex) {
-      changed = true;
-      continue;
-    }
-
-    if (index > removedIndex) {
-      next[index - 1] = status;
-      changed = true;
-      continue;
-    }
-
-    next[index] = status;
-  }
-
-  return changed ? next : previous;
 };

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -753,8 +753,7 @@ export const resources = {
         versionTitle: "Versión {{version}}",
         releaseLabel: "Publicado el {{date}}",
         notFoundTitle: "Versión no encontrada",
-        notFoundDescription:
-          "No se encontró un changelog para esta versión.",
+        notFoundDescription: "No se encontró un changelog para esta versión.",
         latestAction: "Abrir versión actual ({{version}})",
         historyTitle: "Historial de versiones",
         historyAction: "Ver changelog",

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -119,56 +119,25 @@ export const resources = {
           "Thanks for supporting Wordle with your donation.",
         versionUpdateDialog: {
           title: "Updated to {{version}}",
-          description:
-            "You were on {{previousVersion}}. Review the latest changelog and version history.",
-          changelogTitle: "Latest changelog",
+          description: "Congratulations, a new version has been published.",
+          previousVersionLabel: "Previous version: {{previousVersion}}.",
           historyTitle: "Version history",
           releaseLabel: "Version {{version}} · {{date}}",
-          emptyChangelog:
-            "No detailed changelog entries were found for this update range.",
-          closeAction: "Got it",
-          changes: {
-            v0020: [
-              "Migrated Daily cache persistence to `wordle:daily-ref:<YYYY-MM-DD>` + `wordle:daily-meaning:<YYYY-MM-DD>`, stopping new clear-text `wordle:daily-word:*` writes while keeping legacy fallback reads during rollout.",
-              "Added server-authoritative `win` sync (`version: 3`) so backend score updates are recalculated from proof data instead of trusting client `pointsDelta`.",
-              "Hardened anti-fraud round validation and telemetry in backend sync flow, including minimum round-duration checks and rejection-reason tracking.",
-              "Fixed daily shield lifecycle synchronization so shield availability/consumption stays consistent across local cache, remote profile state, and post-loss cleanup.",
-              "Fixed challenge-related score calculations in backend progression updates to keep challenge counters aligned with applied score deltas.",
-              "Extended mode-aware Play navigation so Home and Navbar shortcuts reopen the latest persisted mode, including `zen`.",
-            ],
-            v0018beta: [
-              "Split Scoreboard data by game mode so Classic and Lightning keep independent rankings.",
-              "Added a mode switcher in Scoreboard to toggle between Classic and Lightning tables.",
-              "Extended local/remote score sync contracts with mode-aware stats and event payloads.",
-              "Updated Help navigation/content to support mode-aware guidance (`/ayuda?mode=<modeId>`) from tutorial and navbar entry points.",
-              "Updated Help rules/scoring copy rendering to respect difficulty feature flags, hiding disabled difficulty sections and adjusting formula copy when Insane is unavailable.",
-              "Persisted the current game mode in local storage (`wordle:current-mode`) so Home/Navbar Play shortcuts reopen your latest mode, with fallback to Classic when the stored mode is gated.",
-            ],
-            v0017beta: [
-              "Added a Game Modes hub with a new Lightning mode that challenges players against a countdown timer.",
-              "Introduced the Green challenge alongside per-difficulty feature flags to tune which modes appear in-app.",
-              "Polished scoring and in-game UX with refined dictionary-bonus logic and streak-aware score summaries.",
-            ],
-            v0016beta: [
-              "Added local app-version tracking to detect when a newer frontend build is available in this browser.",
-              "Introduced an update dialog that explains the latest changes and includes a complete in-app version history.",
-              "Improved release communication flow to make post-update context visible right after loading Home.",
-            ],
-            v0016: [
-              "Expanded gameplay settings and quality-of-life controls in Profile for a more configurable experience.",
-              "Refined core Home and Play interactions with additional UX polish and state consistency fixes.",
-            ],
-            v0015: [
-              "Improved dictionary and validation behavior across difficulty levels to align accepted guesses with configured rules.",
-              "Extended scoring and round feedback coverage to keep wins/losses more transparent for players.",
-            ],
-            v0014: [
-              "Optimized startup and route loading to reduce initial bundle pressure and improve perceived load times.",
-              "Enhanced result dialogs with richer round summaries and tighter integration with replay/profile flows.",
-              "Hardened storage contracts to reduce sensitive persistence exposure while keeping resume behavior stable.",
-            ],
-          },
+          historyAction: "View changelog",
+          closeAction: "Close dialog",
+          currentVersionAction: "View current changelog",
         },
+      },
+      changelog: {
+        pageTitle: "Changelog",
+        versionTitle: "Version {{version}}",
+        releaseLabel: "Released on {{date}}",
+        notFoundTitle: "Version not found",
+        notFoundDescription: "No changelog was found for this version.",
+        latestAction: "Open current version ({{version}})",
+        historyTitle: "Version history",
+        historyAction: "View changelog",
+        backHomeAction: "Back to home",
       },
       footer: {
         madeBy: "Made by @sito8943",
@@ -770,56 +739,26 @@ export const resources = {
         donationThankYouAlert: "Gracias por apoyar Wordle con tu donación.",
         versionUpdateDialog: {
           title: "Actualizado a {{version}}",
-          description:
-            "Estabas en {{previousVersion}}. Revisa el changelog más reciente y el historial de versiones.",
-          changelogTitle: "Últimos cambios",
+          description: "Enhorabuena, se ha publicado una nueva versión.",
+          previousVersionLabel: "Versión anterior: {{previousVersion}}.",
           historyTitle: "Historial de versiones",
           releaseLabel: "Versión {{version}} · {{date}}",
-          emptyChangelog:
-            "No se han encontrado entradas detalladas para este rango de actualización.",
-          closeAction: "Entendido",
-          changes: {
-            v0020: [
-              "Se migró la persistencia de caché de Diario a `wordle:daily-ref:<YYYY-MM-DD>` + `wordle:daily-meaning:<YYYY-MM-DD>`, dejando de escribir nuevas entradas en texto plano `wordle:daily-word:*` y manteniendo lectura legacy durante el rollout.",
-              "Se añadió sincronización autoritativa de victorias (`version: 3`), de modo que el backend recalcula la puntuación desde datos de prueba y no confía en `pointsDelta` del cliente.",
-              "Se reforzaron las validaciones anti-fraude y la telemetría del flujo de sync backend, incluyendo control de duración mínima de ronda y registro de motivos de rechazo.",
-              "Se corrigió la sincronización del ciclo de vida del escudo diario para mantener coherente su disponibilidad/consumo entre caché local, estado remoto de perfil y limpieza tras derrota.",
-              "Se corrigieron cálculos de puntuación ligados a retos en la progresión backend para alinear los contadores de retos con los deltas de puntuación aplicados.",
-              "Se amplió la navegación contextual de Jugar para que los accesos de Home y Navbar reabran el último modo persistido, incluido `zen`.",
-            ],
-            v0018beta: [
-              "Se separó la clasificación por modo de juego para que Clásico y Relámpago tengan rankings independientes.",
-              "Se añadió un selector de modo en Clasificación para alternar entre las tablas de Clásico y Relámpago.",
-              "Se amplió el contrato de sincronización local/remota de puntuación con estadísticas y eventos por modo.",
-              "Se actualizó la navegación y contenido de Ayuda para soportar guía contextual por modo (`/ayuda?mode=<modeId>`) desde el tutorial y el navbar.",
-              "Se ajustó el render de reglas/puntuación de Ayuda para respetar feature flags de dificultad, ocultando secciones deshabilitadas y adaptando la fórmula cuando Insano no está disponible.",
-              "Se persistió el modo de juego actual en local storage (`wordle:current-mode`) para que los accesos de Jugar en Home/Navbar reabran el último modo usado, con fallback a Clásico cuando el modo guardado esté bloqueado por feature flag.",
-            ],
-            v0017beta: [
-              "Se añadió un hub de Modos de juego con el nuevo modo Relámpago que reta al jugador contra un temporizador.",
-              "Se incorporó el reto Green junto con feature flags por dificultad para ajustar qué modos aparecen en la app.",
-              "Se pulió la puntuación y la UX en partida con lógica refinada de bonus de diccionario y resúmenes por racha.",
-            ],
-            v0016beta: [
-              "Se añadió seguimiento de la versión de la app en local para detectar builds más nuevas del frontend en este navegador.",
-              "Se incorporó un diálogo de actualización con los cambios recientes y un historial completo de versiones dentro de la app.",
-              "Se mejoró el flujo de comunicación de releases para mostrar contexto de la actualización al cargar Home.",
-            ],
-            v0016: [
-              "Se ampliaron ajustes del juego y controles de calidad de vida en Perfil para una experiencia más configurable.",
-              "Se refinaron interacciones clave de Home y Play con mejoras de UX y mayor consistencia de estado.",
-            ],
-            v0015: [
-              "Se mejoró el comportamiento del diccionario y las validaciones por dificultad para alinear intentos válidos con las reglas activas.",
-              "Se amplió la cobertura de puntuación y feedback de rondas para hacer victorias y derrotas más transparentes.",
-            ],
-            v0014: [
-              "Se optimizó la carga inicial y de rutas para reducir el peso del bundle de arranque y mejorar el tiempo percibido de inicio.",
-              "Se mejoraron los diálogos de resultado con resúmenes de ronda más completos e integración más sólida con rejugar/perfil.",
-              "Se reforzaron contratos de almacenamiento para reducir exposición de datos sensibles manteniendo estable la reanudación de partida.",
-            ],
-          },
+          historyAction: "Ver changelog",
+          closeAction: "Cerrar diálogo",
+          currentVersionAction: "Ver changelog actual",
         },
+      },
+      changelog: {
+        pageTitle: "Changelog",
+        versionTitle: "Versión {{version}}",
+        releaseLabel: "Publicado el {{date}}",
+        notFoundTitle: "Versión no encontrada",
+        notFoundDescription:
+          "No se encontró un changelog para esta versión.",
+        latestAction: "Abrir versión actual ({{version}})",
+        historyTitle: "Historial de versiones",
+        historyAction: "Ver changelog",
+        backHomeAction: "Volver al inicio",
       },
       footer: {
         madeBy: "Hecho por @sito8943",

--- a/src/layouts/View/View.test.tsx
+++ b/src/layouts/View/View.test.tsx
@@ -92,7 +92,10 @@ const renderView = (initialEntry = "/") =>
             <Route index element={<div>Home content</div>} />
             <Route path="play" element={<div>Play content</div>} />
             <Route path="scoreboard" element={<div>Scoreboard content</div>} />
-            <Route path="changelog/:version" element={<ChangelogRouteProbe />} />
+            <Route
+              path="changelog/:version"
+              element={<ChangelogRouteProbe />}
+            />
           </Route>
         </Routes>
       </MemoryRouter>

--- a/src/layouts/View/View.test.tsx
+++ b/src/layouts/View/View.test.tsx
@@ -5,7 +5,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router";
+import { MemoryRouter, Route, Routes, useParams } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { env } from "@config";
 import { DialogQueueProvider } from "@providers";
@@ -58,6 +58,12 @@ const updatePlayerMock = vi.fn().mockResolvedValue(undefined);
 const recoverPlayerMock = vi.fn().mockResolvedValue(undefined);
 const isNickAvailableMock = vi.fn().mockResolvedValue(true);
 
+const ChangelogRouteProbe = () => {
+  const { version } = useParams();
+
+  return <div>{`Changelog content ${version ?? ""}`}</div>;
+};
+
 vi.mock("@providers", async () => {
   const actual =
     await vi.importActual<typeof import("@providers")>("@providers");
@@ -86,6 +92,7 @@ const renderView = (initialEntry = "/") =>
             <Route index element={<div>Home content</div>} />
             <Route path="play" element={<div>Play content</div>} />
             <Route path="scoreboard" element={<div>Scoreboard content</div>} />
+            <Route path="changelog/:version" element={<ChangelogRouteProbe />} />
           </Route>
         </Routes>
       </MemoryRouter>
@@ -136,18 +143,19 @@ describe("View app version dialog", () => {
     expect(screen.getByText("Scoreboard content")).toBeTruthy();
     expect(screen.getByText("Updated to 0.0.16-beta")).toBeTruthy();
     expect(
-      screen.getByText(
-        "You were on 0.0.15. Review the latest changelog and version history.",
-      ),
+      screen.getByText("Congratulations, a new version has been published."),
     ).toBeTruthy();
-    expect(screen.getByText("Latest changelog")).toBeTruthy();
+    expect(screen.getByText("Version history")).toBeTruthy();
     expect(localStorage.getItem(APP_VERSION_STORAGE_KEY)).toBe("0.0.15");
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Close" })[0]);
+    fireEvent.click(
+      screen.getByRole("button", { name: "View current changelog" }),
+    );
 
     await waitFor(() => {
       expect(localStorage.getItem(APP_VERSION_STORAGE_KEY)).toBe("0.0.16-beta");
     });
+    expect(screen.getByText("Changelog content 0.0.16-beta")).toBeTruthy();
   });
 
   it("shows pending update dialog details when previous app version is preserved after storage reset", async () => {
@@ -159,12 +167,11 @@ describe("View app version dialog", () => {
 
     expect(screen.getByText("Updated to 0.0.16-beta")).toBeTruthy();
     expect(
-      screen.getByText(
-        "You were on 0.0.15. Review the latest changelog and version history.",
-      ),
+      screen.getByText("Congratulations, a new version has been published."),
     ).toBeTruthy();
+    expect(screen.getByText("Previous version: 0.0.15.")).toBeTruthy();
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Close" })[0]);
+    fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
 
     await waitFor(() => {
       expect(localStorage.getItem(PREVIOUS_APP_VERSION_STORAGE_KEY)).toBeNull();

--- a/src/layouts/View/View.tsx
+++ b/src/layouts/View/View.tsx
@@ -1,10 +1,4 @@
-import {
-  lazy,
-  Suspense,
-  useCallback,
-  useEffect,
-  useState,
-} from "react";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router";
 import { ErrorBoundary, ErrorFallback } from "@components";
 import { useTranslation } from "@i18n";

--- a/src/layouts/View/View.tsx
+++ b/src/layouts/View/View.tsx
@@ -3,10 +3,9 @@ import {
   Suspense,
   useCallback,
   useEffect,
-  useMemo,
   useState,
 } from "react";
-import { Outlet, useLocation } from "react-router";
+import { Outlet, useLocation, useNavigate } from "react-router";
 import { ErrorBoundary, ErrorFallback } from "@components";
 import { useTranslation } from "@i18n";
 import { Navbar, Footer } from "./components";
@@ -19,13 +18,13 @@ import {
 } from "@providers";
 import { normalizePlayerName } from "@providers/Player/utils";
 import { env } from "@config/env";
-import { ROUTES } from "@config/routes";
-import { VIEW_DIALOG_IDS, VIEW_VERSION_HISTORY } from "./constants";
+import { ROUTES, getChangelogRoute } from "@config/routes";
+import { VIEW_DIALOG_IDS } from "./constants";
+import { VIEW_VERSION_HISTORY } from "./changelog";
 import {
   clearPendingPreviousAppVersion,
   getPendingPreviousAppVersion,
   getStoredAppVersion,
-  getVersionHistoryEntriesForUpdate,
   isVersionNewer,
   shouldAskForInitialPlayerName,
   storeAppVersion,
@@ -42,6 +41,8 @@ const View = () => {
   const { scoreClient } = useApi();
   const { player, recoverPlayer, updatePlayer } = usePlayer();
   const { pathname, hash } = useLocation();
+  const navigate = useNavigate();
+  const appVersion = env.appVersion;
   const isHomeRoute = pathname === ROUTES.HOME;
   useThemePreference({ applyToDocument: true });
   useAnimationsPreference({ applyToDocument: true });
@@ -63,11 +64,28 @@ const View = () => {
     DIALOG_QUEUE_PRIORITIES.VIEW,
   );
 
+  const markVersionDialogAsSeen = useCallback(() => {
+    storeAppVersion(appVersion);
+    clearPendingPreviousAppVersion();
+  }, [appVersion]);
+
   const closeVersionDialog = useCallback(() => {
     setVersionDialogVisible(false);
-    storeAppVersion(env.appVersion);
-    clearPendingPreviousAppVersion();
-  }, []);
+    markVersionDialogAsSeen();
+  }, [markVersionDialogAsSeen]);
+
+  const openVersionChangelog = useCallback(
+    (version: string) => {
+      setVersionDialogVisible(false);
+      markVersionDialogAsSeen();
+      navigate(getChangelogRoute(version));
+    },
+    [markVersionDialogAsSeen, navigate],
+  );
+
+  const openCurrentVersionChangelog = useCallback(() => {
+    openVersionChangelog(appVersion);
+  }, [appVersion, openVersionChangelog]);
 
   const confirmInitialPlayerName = useCallback(
     async (name: string): Promise<string | null> => {
@@ -118,7 +136,7 @@ const View = () => {
   );
 
   useEffect(() => {
-    const currentVersion = env.appVersion;
+    const currentVersion = appVersion;
     const pendingPreviousVersion = getPendingPreviousAppVersion();
 
     if (pendingPreviousVersion) {
@@ -145,27 +163,7 @@ const View = () => {
       setVersionDialogVisible(true);
       return;
     }
-  }, []);
-
-  const changelogEntries = useMemo(() => {
-    if (!previousAppVersion) {
-      const currentVersionEntry = VIEW_VERSION_HISTORY.find(
-        (entry) => entry.version === env.appVersion,
-      );
-
-      if (currentVersionEntry) {
-        return [currentVersionEntry];
-      }
-
-      return VIEW_VERSION_HISTORY.slice(0, 1);
-    }
-
-    return getVersionHistoryEntriesForUpdate(
-      VIEW_VERSION_HISTORY,
-      previousAppVersion,
-      env.appVersion,
-    );
-  }, [previousAppVersion]);
+  }, [appVersion]);
 
   useEffect(() => {
     if (hash.length <= 1) {
@@ -256,9 +254,10 @@ const View = () => {
           <VersionUpdateDialog
             visible={queuedVersionDialogVisible}
             onClose={closeVersionDialog}
-            currentVersion={env.appVersion}
+            onOpenCurrentChangelog={openCurrentVersionChangelog}
+            onOpenVersionChangelog={openVersionChangelog}
+            currentVersion={appVersion}
             previousVersion={previousAppVersion}
-            changelogEntries={changelogEntries}
             versionHistory={VIEW_VERSION_HISTORY}
           />
         ) : null}

--- a/src/layouts/View/changelog.json
+++ b/src/layouts/View/changelog.json
@@ -1,0 +1,132 @@
+{
+  "0.0.21": {
+    "releasedAt": "2026-05-04",
+    "language": {
+      "en": [
+        "Moved the full changelog out of the update dialog into a dedicated route: `/changelog/:version`.",
+        "Simplified the app-update dialog to a release announcement with two CTAs: view current changelog or close dialog.",
+        "Added version history links in the update dialog so each listed version opens its own changelog page.",
+        "Centralized release notes in a JSON contract keyed by `version` and `language` (`en`/`es`) for consistent rendering."
+      ],
+      "es": [
+        "Se movió el changelog completo fuera del diálogo de actualización a una ruta dedicada: `/changelog/:version`.",
+        "Se simplificó el diálogo de actualización a un aviso de nueva versión con dos CTAs: ver changelog actual o cerrar diálogo.",
+        "Se añadieron enlaces en el historial de versiones del diálogo para que cada versión abra su página de changelog.",
+        "Se centralizaron las notas de versión en un contrato JSON con clave por `version` y `language` (`en`/`es`) para un render consistente."
+      ]
+    }
+  },
+  "0.0.20": {
+    "releasedAt": "2026-04-29",
+    "language": {
+      "en": [
+        "Migrated Daily cache persistence to `wordle:daily-ref:<YYYY-MM-DD>` + `wordle:daily-meaning:<YYYY-MM-DD>`, stopping new clear-text `wordle:daily-word:*` writes while keeping legacy fallback reads during rollout.",
+        "Added server-authoritative `win` sync (`version: 3`) so backend score updates are recalculated from proof data instead of trusting client `pointsDelta`.",
+        "Hardened anti-fraud round validation and telemetry in backend sync flow, including minimum round-duration checks and rejection-reason tracking.",
+        "Fixed daily shield lifecycle synchronization so shield availability/consumption stays consistent across local cache, remote profile state, and post-loss cleanup.",
+        "Fixed challenge-related score calculations in backend progression updates to keep challenge counters aligned with applied score deltas.",
+        "Extended mode-aware Play navigation so Home and Navbar shortcuts reopen the latest persisted mode, including `zen`."
+      ],
+      "es": [
+        "Se migró la persistencia de caché de Diario a `wordle:daily-ref:<YYYY-MM-DD>` + `wordle:daily-meaning:<YYYY-MM-DD>`, dejando de escribir nuevas entradas en texto plano `wordle:daily-word:*` y manteniendo lectura legacy durante el rollout.",
+        "Se añadió sincronización autoritativa de victorias (`version: 3`), de modo que el backend recalcula la puntuación desde datos de prueba y no confía en `pointsDelta` del cliente.",
+        "Se reforzaron las validaciones anti-fraude y la telemetría del flujo de sync backend, incluyendo control de duración mínima de ronda y registro de motivos de rechazo.",
+        "Se corrigió la sincronización del ciclo de vida del escudo diario para mantener coherente su disponibilidad/consumo entre caché local, estado remoto de perfil y limpieza tras derrota.",
+        "Se corrigieron cálculos de puntuación ligados a retos en la progresión backend para alinear los contadores de retos con los deltas de puntuación aplicados.",
+        "Se amplió la navegación contextual de Jugar para que los accesos de Home y Navbar reabran el último modo persistido, incluido `zen`."
+      ]
+    }
+  },
+  "0.0.18-beta": {
+    "releasedAt": "2026-04-20",
+    "language": {
+      "en": [
+        "Split Scoreboard data by game mode so Classic and Lightning keep independent rankings.",
+        "Added a mode switcher in Scoreboard to toggle between Classic and Lightning tables.",
+        "Extended local/remote score sync contracts with mode-aware stats and event payloads.",
+        "Updated Help navigation/content to support mode-aware guidance (`/ayuda?mode=<modeId>`) from tutorial and navbar entry points.",
+        "Updated Help rules/scoring copy rendering to respect difficulty feature flags, hiding disabled difficulty sections and adjusting formula copy when Insane is unavailable.",
+        "Persisted the current game mode in local storage (`wordle:current-mode`) so Home/Navbar Play shortcuts reopen your latest mode, with fallback to Classic when the stored mode is gated."
+      ],
+      "es": [
+        "Se separó la clasificación por modo de juego para que Clásico y Relámpago tengan rankings independientes.",
+        "Se añadió un selector de modo en Clasificación para alternar entre las tablas de Clásico y Relámpago.",
+        "Se amplió el contrato de sincronización local/remota de puntuación con estadísticas y eventos por modo.",
+        "Se actualizó la navegación y contenido de Ayuda para soportar guía contextual por modo (`/ayuda?mode=<modeId>`) desde el tutorial y el navbar.",
+        "Se ajustó el render de reglas/puntuación de Ayuda para respetar feature flags de dificultad, ocultando secciones deshabilitadas y adaptando la fórmula cuando Insano no está disponible.",
+        "Se persistió el modo de juego actual en local storage (`wordle:current-mode`) para que los accesos de Jugar en Home/Navbar reabran el último modo usado, con fallback a Clásico cuando el modo guardado esté bloqueado por feature flag."
+      ]
+    }
+  },
+  "0.0.17-beta": {
+    "releasedAt": "2026-04-19",
+    "language": {
+      "en": [
+        "Added a Game Modes hub with a new Lightning mode that challenges players against a countdown timer.",
+        "Introduced the Green challenge alongside per-difficulty feature flags to tune which modes appear in-app.",
+        "Polished scoring and in-game UX with refined dictionary-bonus logic and streak-aware score summaries."
+      ],
+      "es": [
+        "Se añadió un hub de Modos de juego con el nuevo modo Relámpago que reta al jugador contra un temporizador.",
+        "Se incorporó el reto Green junto con feature flags por dificultad para ajustar qué modos aparecen en la app.",
+        "Se pulió la puntuación y la UX en partida con lógica refinada de bonus de diccionario y resúmenes por racha."
+      ]
+    }
+  },
+  "0.0.16-beta": {
+    "releasedAt": "2026-04-16",
+    "language": {
+      "en": [
+        "Added local app-version tracking to detect when a newer frontend build is available in this browser.",
+        "Introduced an update dialog that explains the latest changes and includes a complete in-app version history.",
+        "Improved release communication flow to make post-update context visible right after loading Home."
+      ],
+      "es": [
+        "Se añadió seguimiento de la versión de la app en local para detectar builds más nuevas del frontend en este navegador.",
+        "Se incorporó un diálogo de actualización con los cambios recientes y un historial completo de versiones dentro de la app.",
+        "Se mejoró el flujo de comunicación de releases para mostrar contexto de la actualización al cargar Home."
+      ]
+    }
+  },
+  "0.0.16": {
+    "releasedAt": "2026-04-13",
+    "language": {
+      "en": [
+        "Expanded gameplay settings and quality-of-life controls in Profile for a more configurable experience.",
+        "Refined core Home and Play interactions with additional UX polish and state consistency fixes."
+      ],
+      "es": [
+        "Se ampliaron ajustes del juego y controles de calidad de vida en Perfil para una experiencia más configurable.",
+        "Se refinaron interacciones clave de Home y Play con mejoras de UX y mayor consistencia de estado."
+      ]
+    }
+  },
+  "0.0.15": {
+    "releasedAt": "2026-04-08",
+    "language": {
+      "en": [
+        "Improved dictionary and validation behavior across difficulty levels to align accepted guesses with configured rules.",
+        "Extended scoring and round feedback coverage to keep wins/losses more transparent for players."
+      ],
+      "es": [
+        "Se mejoró el comportamiento del diccionario y las validaciones por dificultad para alinear intentos válidos con las reglas activas.",
+        "Se amplió la cobertura de puntuación y feedback de rondas para hacer victorias y derrotas más transparentes."
+      ]
+    }
+  },
+  "0.0.14": {
+    "releasedAt": "2026-04-02",
+    "language": {
+      "en": [
+        "Optimized startup and route loading to reduce initial bundle pressure and improve perceived load times.",
+        "Enhanced result dialogs with richer round summaries and tighter integration with replay/profile flows.",
+        "Hardened storage contracts to reduce sensitive persistence exposure while keeping resume behavior stable."
+      ],
+      "es": [
+        "Se optimizó la carga inicial y de rutas para reducir el peso del bundle de arranque y mejorar el tiempo percibido de inicio.",
+        "Se mejoraron los diálogos de resultado con resúmenes de ronda más completos e integración más sólida con rejugar/perfil.",
+        "Se reforzaron contratos de almacenamiento para reducir exposición de datos sensibles manteniendo estable la reanudación de partida."
+      ]
+    }
+  }
+}

--- a/src/layouts/View/changelog.json
+++ b/src/layouts/View/changelog.json
@@ -3,16 +3,30 @@
     "releasedAt": "2026-05-04",
     "language": {
       "en": [
-        "Moved the full changelog out of the update dialog into a dedicated route: `/changelog/:version`.",
-        "Simplified the app-update dialog to a release announcement with two CTAs: view current changelog or close dialog.",
-        "Added version history links in the update dialog so each listed version opens its own changelog page.",
-        "Centralized release notes in a JSON contract keyed by `version` and `language` (`en`/`es`) for consistent rendering."
+        "Bumped package version to `0.0.21`.",
+        "Added a dedicated changelog page route (`/changelog/:version`) and wired it into app routing.",
+        "Moved changelog content to a typed JSON source (`src/layouts/View/changelog.json`) with entries keyed by `version` and localized by `language` (`en`/`es`), plus helper resolvers/history derivation in `src/layouts/View/changelog.ts`.",
+        "Simplified the version-update dialog flow: release announcement copy, linkable version history, and direct CTA to open the current changelog page.",
+        "Added a full changelog view with release metadata, per-version navigation links, not-found fallback, and a two-column version-history grid.",
+        "Introduced reusable `Switcher` and `SwitcherField` components and replaced checkbox toggles in Profile Settings and Play Settings Drawer with the new switch UI.",
+        "Hardened Switcher typing/accessibility by explicitly supporting common input props and ARIA attributes through the component API.",
+        "Fixed manual tile selection editing so letter insertion in manual mode now advances the active tile index after writing.",
+        "Fixed manual-mode backspace behavior so it clears the selected tile and moves the cursor left, allowing consecutive deletions.",
+        "Fixed selected-index deletion behavior so remaining letters no longer shift left unexpectedly (`removeLetterAt` now clears in-place and trims trailing blanks).",
+        "Fixed Profile page bottom spacing to avoid footer overlap by adding safe-area aware bottom padding."
       ],
       "es": [
-        "Se movió el changelog completo fuera del diálogo de actualización a una ruta dedicada: `/changelog/:version`.",
-        "Se simplificó el diálogo de actualización a un aviso de nueva versión con dos CTAs: ver changelog actual o cerrar diálogo.",
-        "Se añadieron enlaces en el historial de versiones del diálogo para que cada versión abra su página de changelog.",
-        "Se centralizaron las notas de versión en un contrato JSON con clave por `version` y `language` (`en`/`es`) para un render consistente."
+        "Se actualizó la versión del paquete a `0.0.21`.",
+        "Se añadió una ruta dedicada para changelog (`/changelog/:version`) y se integró en el enrutado de la app.",
+        "Se movió el contenido del changelog a una fuente JSON tipada (`src/layouts/View/changelog.json`) con entradas por `version` e idioma (`en`/`es`), junto con helpers de resolución/historial en `src/layouts/View/changelog.ts`.",
+        "Se simplificó el flujo del diálogo de actualización: mensaje de release, historial enlazable y CTA directo para abrir el changelog actual.",
+        "Se añadió una vista completa de changelog con metadatos de release, enlaces por versión, fallback de versión no encontrada y grid de historial en dos columnas.",
+        "Se introdujeron los componentes reutilizables `Switcher` y `SwitcherField`, sustituyendo checkboxes en Ajustes de Perfil y en el panel de ajustes de Play.",
+        "Se reforzó el tipado/accesibilidad de Switcher soportando props comunes del input y atributos ARIA de forma explícita en la API.",
+        "Se corrigió la edición con selección manual de casillas para que insertar letras avance el índice activo en modo manual.",
+        "Se corrigió el comportamiento de backspace en modo manual para borrar la casilla seleccionada y mover el cursor a la izquierda, permitiendo borrados consecutivos.",
+        "Se corrigió el borrado por índice seleccionado para que el resto de letras no se desplacen inesperadamente (`removeLetterAt` ahora limpia en sitio y recorta espacios finales).",
+        "Se corrigió el espaciado inferior de la vista de Perfil para evitar solapamiento con el footer añadiendo padding adaptado a safe area."
       ]
     }
   },

--- a/src/layouts/View/changelog.ts
+++ b/src/layouts/View/changelog.ts
@@ -1,0 +1,64 @@
+import changelogRaw from "./changelog.json?raw";
+import { compareAppVersions } from "./utils";
+import type {
+  ResolvedVersionChangelog,
+  ViewChangelogByVersion,
+  ViewChangelogLanguage,
+  ViewVersionHistoryEntry,
+} from "./types";
+
+const normalizeChangelogLanguage = (value: string): ViewChangelogLanguage => {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "es" || normalized.startsWith("es-")) {
+    return "es";
+  }
+
+  return "en";
+};
+
+const resolveChangelogData = (): ViewChangelogByVersion => {
+  try {
+    return JSON.parse(changelogRaw) as ViewChangelogByVersion;
+  } catch {
+    return {};
+  }
+};
+
+export const VIEW_CHANGELOG_BY_VERSION = resolveChangelogData();
+
+export const VIEW_VERSION_HISTORY: ViewVersionHistoryEntry[] = Object.entries(
+  VIEW_CHANGELOG_BY_VERSION,
+)
+  .map(([version, entry]) => ({
+    version,
+    releasedAt: entry.releasedAt,
+  }))
+  .sort((left, right) => {
+    if (left.releasedAt !== right.releasedAt) {
+      return right.releasedAt.localeCompare(left.releasedAt);
+    }
+
+    return compareAppVersions(right.version, left.version);
+  });
+
+export const getResolvedVersionChangelog = (
+  version: string,
+  language: string,
+): ResolvedVersionChangelog | null => {
+  const entry = VIEW_CHANGELOG_BY_VERSION[version];
+  if (!entry) {
+    return null;
+  }
+
+  const normalizedLanguage = normalizeChangelogLanguage(language);
+  const fallbackLanguage: ViewChangelogLanguage =
+    normalizedLanguage === "es" ? "en" : "es";
+  const changes =
+    entry.language[normalizedLanguage] ?? entry.language[fallbackLanguage] ?? [];
+
+  return {
+    version,
+    releasedAt: entry.releasedAt,
+    changes,
+  };
+};

--- a/src/layouts/View/changelog.ts
+++ b/src/layouts/View/changelog.ts
@@ -54,7 +54,9 @@ export const getResolvedVersionChangelog = (
   const fallbackLanguage: ViewChangelogLanguage =
     normalizedLanguage === "es" ? "en" : "es";
   const changes =
-    entry.language[normalizedLanguage] ?? entry.language[fallbackLanguage] ?? [];
+    entry.language[normalizedLanguage] ??
+    entry.language[fallbackLanguage] ??
+    [];
 
   return {
     version,

--- a/src/layouts/View/components/VersionUpdateDialog/VersionUpdateDialog.tsx
+++ b/src/layouts/View/components/VersionUpdateDialog/VersionUpdateDialog.tsx
@@ -1,13 +1,16 @@
 import { Button, Dialog } from "@components";
+import { getChangelogRoute } from "@config/routes";
 import { useTranslation } from "@i18n";
+import { Link } from "react-router";
 import type { VersionUpdateDialogProps } from "./types";
 
 const VersionUpdateDialog = ({
   visible,
   onClose,
+  onOpenCurrentChangelog,
+  onOpenVersionChangelog,
   currentVersion,
   previousVersion,
-  changelogEntries,
   versionHistory,
 }: VersionUpdateDialogProps) => {
   const { t, i18n } = useTranslation();
@@ -18,7 +21,10 @@ const VersionUpdateDialog = ({
       return value;
     }
 
-    const locale = i18n.language === "es" ? "es-ES" : "en-US";
+    const locale =
+      i18n.language === "es" || i18n.language.startsWith("es-")
+        ? "es-ES"
+        : "en-US";
     return new Intl.DateTimeFormat(locale, { dateStyle: "medium" }).format(
       parsedDate,
     );
@@ -30,47 +36,18 @@ const VersionUpdateDialog = ({
       onClose={onClose}
       titleId="app-version-update-dialog-title"
       title={t("home.versionUpdateDialog.title", { version: currentVersion })}
-      description={
-        previousVersion
-          ? t("home.versionUpdateDialog.description", { previousVersion })
-          : undefined
-      }
-      panelClassName="max-w-2xl"
+      description={t("home.versionUpdateDialog.description")}
+      headerAction={<span aria-hidden="true" />}
+      panelClassName="max-w-xl"
     >
       <div className="mt-4 flex max-h-[65vh] flex-col gap-5 overflow-y-auto pr-1">
-        <section>
-          <h3 className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
-            {t("home.versionUpdateDialog.changelogTitle")}
-          </h3>
-          {changelogEntries.length > 0 ? (
-            <ol className="mt-3 flex flex-col gap-3">
-              {changelogEntries.map((entry) => (
-                <li
-                  key={`changelog-${entry.version}`}
-                  className="rounded-md border border-primary bg-primary/10 p-3 dark:border-primary dark:bg-primary/20"
-                >
-                  <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
-                    {t("home.versionUpdateDialog.releaseLabel", {
-                      version: entry.version,
-                      date: formatReleaseDate(entry.releasedAt),
-                    })}
-                  </p>
-                  <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-neutral-700 dark:text-neutral-300">
-                    {entry.changeKeys.map((changeKey) => (
-                      <li key={`${entry.version}-${changeKey}`}>
-                        {t(changeKey)}
-                      </li>
-                    ))}
-                  </ul>
-                </li>
-              ))}
-            </ol>
-          ) : (
-            <p className="mt-3 text-sm text-neutral-700 dark:text-neutral-300">
-              {t("home.versionUpdateDialog.emptyChangelog")}
-            </p>
-          )}
-        </section>
+        {previousVersion ? (
+          <p className="text-sm text-neutral-700 dark:text-neutral-300">
+            {t("home.versionUpdateDialog.previousVersionLabel", {
+              previousVersion,
+            })}
+          </p>
+        ) : null}
         <section>
           <h3 className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
             {t("home.versionUpdateDialog.historyTitle")}
@@ -94,21 +71,27 @@ const VersionUpdateDialog = ({
                       date: formatReleaseDate(entry.releasedAt),
                     })}
                   </p>
-                  <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-neutral-700 dark:text-neutral-300">
-                    {entry.changeKeys.map((changeKey) => (
-                      <li key={`${entry.version}-${changeKey}`}>
-                        {t(changeKey)}
-                      </li>
-                    ))}
-                  </ul>
+                  <Link
+                    to={getChangelogRoute(entry.version)}
+                    className="mt-2 text-sm font-semibold text-primary underline decoration-primary/40 underline-offset-2 transition-colors hover:text-primary/80"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      onOpenVersionChangelog(entry.version);
+                    }}
+                  >
+                    {t("home.versionUpdateDialog.historyAction")}
+                  </Link>
                 </li>
               );
             })}
           </ol>
         </section>
-        <div className="flex justify-end">
-          <Button onClick={onClose}>
+        <div className="flex flex-wrap justify-end gap-2">
+          <Button variant="outline" color="neutral" onClick={onClose}>
             {t("home.versionUpdateDialog.closeAction")}
+          </Button>
+          <Button onClick={onOpenCurrentChangelog}>
+            {t("home.versionUpdateDialog.currentVersionAction")}
           </Button>
         </div>
       </div>

--- a/src/layouts/View/components/VersionUpdateDialog/types.ts
+++ b/src/layouts/View/components/VersionUpdateDialog/types.ts
@@ -3,8 +3,9 @@ import type { ViewVersionHistoryEntry } from "../../types";
 export type VersionUpdateDialogProps = {
   visible: boolean;
   onClose: () => void;
+  onOpenCurrentChangelog: () => void;
+  onOpenVersionChangelog: (version: string) => void;
   currentVersion: string;
   previousVersion: string | null;
-  changelogEntries: ViewVersionHistoryEntry[];
   versionHistory: ViewVersionHistoryEntry[];
 };

--- a/src/layouts/View/constants.ts
+++ b/src/layouts/View/constants.ts
@@ -1,5 +1,3 @@
-import type { ViewVersionHistoryEntry } from "./types";
-
 export const PLAYER_STORAGE_KEY = "player";
 export const APP_VERSION_STORAGE_KEY = "wordle:app-version";
 export const PREVIOUS_APP_VERSION_STORAGE_KEY = "wordle:app-version:previous";
@@ -7,73 +5,3 @@ export const VIEW_DIALOG_IDS = {
   INITIAL_PLAYER: "view:initial-player",
   VERSION_UPDATE: "view:version-update",
 } as const;
-
-export const VIEW_VERSION_HISTORY: ViewVersionHistoryEntry[] = [
-  {
-    version: "0.0.20",
-    releasedAt: "2026-04-29",
-    changeKeys: [
-      "home.versionUpdateDialog.changes.v0020.0",
-      "home.versionUpdateDialog.changes.v0020.1",
-      "home.versionUpdateDialog.changes.v0020.2",
-      "home.versionUpdateDialog.changes.v0020.3",
-      "home.versionUpdateDialog.changes.v0020.4",
-      "home.versionUpdateDialog.changes.v0020.5",
-    ],
-  },
-  {
-    version: "0.0.18-beta",
-    releasedAt: "2026-04-20",
-    changeKeys: [
-      "home.versionUpdateDialog.changes.v0018beta.0",
-      "home.versionUpdateDialog.changes.v0018beta.1",
-      "home.versionUpdateDialog.changes.v0018beta.2",
-      "home.versionUpdateDialog.changes.v0018beta.3",
-      "home.versionUpdateDialog.changes.v0018beta.4",
-      "home.versionUpdateDialog.changes.v0018beta.5",
-    ],
-  },
-  {
-    version: "0.0.17-beta",
-    releasedAt: "2026-04-19",
-    changeKeys: [
-      "home.versionUpdateDialog.changes.v0017beta.0",
-      "home.versionUpdateDialog.changes.v0017beta.1",
-      "home.versionUpdateDialog.changes.v0017beta.2",
-    ],
-  },
-  {
-    version: "0.0.16-beta",
-    releasedAt: "2026-04-16",
-    changeKeys: [
-      "home.versionUpdateDialog.changes.v0016beta.0",
-      "home.versionUpdateDialog.changes.v0016beta.1",
-      "home.versionUpdateDialog.changes.v0016beta.2",
-    ],
-  },
-  {
-    version: "0.0.16",
-    releasedAt: "2026-04-13",
-    changeKeys: [
-      "home.versionUpdateDialog.changes.v0016.0",
-      "home.versionUpdateDialog.changes.v0016.1",
-    ],
-  },
-  {
-    version: "0.0.15",
-    releasedAt: "2026-04-08",
-    changeKeys: [
-      "home.versionUpdateDialog.changes.v0015.0",
-      "home.versionUpdateDialog.changes.v0015.1",
-    ],
-  },
-  {
-    version: "0.0.14",
-    releasedAt: "2026-04-02",
-    changeKeys: [
-      "home.versionUpdateDialog.changes.v0014.0",
-      "home.versionUpdateDialog.changes.v0014.1",
-      "home.versionUpdateDialog.changes.v0014.2",
-    ],
-  },
-];

--- a/src/layouts/View/types.ts
+++ b/src/layouts/View/types.ts
@@ -1,5 +1,19 @@
 export type ViewVersionHistoryEntry = {
   version: string;
   releasedAt: string;
-  changeKeys: string[];
+};
+
+export type ViewChangelogLanguage = "en" | "es";
+
+export type ViewChangelogEntry = {
+  releasedAt: string;
+  language: Record<ViewChangelogLanguage, string[]>;
+};
+
+export type ViewChangelogByVersion = Record<string, ViewChangelogEntry>;
+
+export type ResolvedVersionChangelog = {
+  version: string;
+  releasedAt: string;
+  changes: string[];
 };

--- a/src/layouts/View/utils.test.ts
+++ b/src/layouts/View/utils.test.ts
@@ -3,8 +3,8 @@ import {
   APP_VERSION_STORAGE_KEY,
   PLAYER_STORAGE_KEY,
   PREVIOUS_APP_VERSION_STORAGE_KEY,
-  VIEW_VERSION_HISTORY,
 } from "./constants";
+import { VIEW_VERSION_HISTORY } from "./changelog";
 import {
   clearPendingPreviousAppVersion,
   compareAppVersions,

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -11,6 +11,7 @@ const Play = lazy(() => import("@views/Play"));
 const Help = lazy(() => import("@views/Help"));
 const Scoreboard = lazy(() => import("@views/Scoreboard"));
 const Profile = lazy(() => import("@views/Profile"));
+const Changelog = lazy(() => import("@views/Changelog"));
 const NotFound = lazy(() => import("@views/NotFound"));
 const Zen = lazy(() => import("@views/GameModes/Zen"));
 const Lightning = lazy(() => import("@views/GameModes/Lightning"));
@@ -30,6 +31,7 @@ const routes = createBrowserRouter(
         },
         { path: ROUTES.LIGHTING, element: <Lightning /> },
         { path: ROUTES.DAILY, element: <Daily /> },
+        { path: ROUTES.CHANGELOG, element: <Changelog /> },
         { path: ROUTES.ZEN, element: <Zen /> },
         { path: ROUTES.HELP, element: <Help /> },
         { path: ROUTES.SCOREBOARD, element: <Scoreboard /> },

--- a/src/views/Changelog/Changelog.test.tsx
+++ b/src/views/Changelog/Changelog.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { ROUTES } from "@config/routes";
+import { i18n, initI18n } from "@i18n";
+import Changelog from "./Changelog";
+
+const renderChangelog = (entry: string) =>
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path={ROUTES.CHANGELOG} element={<Changelog />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+afterEach(cleanup);
+
+beforeAll(async () => {
+  await initI18n();
+});
+
+beforeEach(async () => {
+  await i18n.changeLanguage("en");
+});
+
+describe("Changelog", () => {
+  it("renders the selected version changelog", () => {
+    renderChangelog("/changelog/0.0.16-beta");
+
+    expect(
+      screen.getByRole("heading", { name: "Changelog", level: 2 }),
+    ).toBeTruthy();
+    expect(screen.getByText("Version 0.0.16-beta")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Added local app-version tracking to detect when a newer frontend build is available in this browser.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("renders not found content when version does not exist", () => {
+    renderChangelog("/changelog/9.9.9");
+
+    expect(screen.getByText("Version not found")).toBeTruthy();
+    expect(
+      screen.getByText("No changelog was found for this version."),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Open current version (0.0.21)" }),
+    ).toBeTruthy();
+  });
+
+  it("renders localized changelog entries in spanish", async () => {
+    await i18n.changeLanguage("es");
+    renderChangelog("/changelog/0.0.16-beta");
+
+    expect(screen.getByText("Versión 0.0.16-beta")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Se añadió seguimiento de la versión de la app en local para detectar builds más nuevas del frontend en este navegador.",
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/src/views/Changelog/Changelog.test.tsx
+++ b/src/views/Changelog/Changelog.test.tsx
@@ -1,13 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
-import {
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { ROUTES } from "@config/routes";
 import { i18n, initI18n } from "@i18n";
 import Changelog from "./Changelog";

--- a/src/views/Changelog/Changelog.tsx
+++ b/src/views/Changelog/Changelog.tsx
@@ -48,7 +48,7 @@ const Changelog = (): JSX.Element => {
             onClick={() => {
               navigate(ROUTES.HOME);
             }}
-            className="!p-0"
+            className="p-0!"
           ></Button>
           <h2 className="page-title">{t("changelog.pageTitle")}</h2>
         </div>

--- a/src/views/Changelog/Changelog.tsx
+++ b/src/views/Changelog/Changelog.tsx
@@ -1,0 +1,143 @@
+import type { JSX } from "react";
+import { Link, useNavigate, useParams } from "react-router";
+import { ROUTES, getChangelogRoute } from "@config/routes";
+import { useTranslation } from "@i18n";
+import { Button } from "@components";
+import { faChevronLeft } from "@fortawesome/free-solid-svg-icons";
+import {
+  VIEW_VERSION_HISTORY,
+  getResolvedVersionChangelog,
+} from "@layouts/View/changelog";
+
+const Changelog = (): JSX.Element => {
+  const { t, i18n } = useTranslation();
+  const { version } = useParams();
+  const navigate = useNavigate();
+  const currentVersion = version ?? "";
+  const latestVersion = VIEW_VERSION_HISTORY[0]?.version;
+  const changelog = version
+    ? getResolvedVersionChangelog(version, i18n.language)
+    : null;
+
+  const formatReleaseDate = (value: string): string => {
+    const parsedDate = new Date(`${value}T00:00:00`);
+    if (Number.isNaN(parsedDate.getTime())) {
+      return value;
+    }
+
+    const locale =
+      i18n.language === "es" || i18n.language.startsWith("es-")
+        ? "es-ES"
+        : "en-US";
+    return new Intl.DateTimeFormat(locale, { dateStyle: "medium" }).format(
+      parsedDate,
+    );
+  };
+
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-4 py-8 pb-16">
+      <section
+        className="settings-entrance my-0!"
+        style={{ animationDelay: "0ms" }}
+      >
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            variant="ghost"
+            color="neutral"
+            icon={faChevronLeft}
+            onClick={() => {
+              navigate(ROUTES.HOME);
+            }}
+            className="!p-0"
+          ></Button>
+          <h2 className="page-title">{t("changelog.pageTitle")}</h2>
+        </div>
+        {version ? (
+          <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+            {t("changelog.versionTitle", { version })}
+          </p>
+        ) : null}
+        {changelog ? (
+          <p className="mt-1 text-sm text-neutral-700 dark:text-neutral-300">
+            {t("changelog.releaseLabel", {
+              date: formatReleaseDate(changelog.releasedAt),
+            })}
+          </p>
+        ) : null}
+      </section>
+
+      {changelog ? (
+        <section
+          className="settings-entrance my-0!"
+          style={{ animationDelay: "80ms" }}
+        >
+          <ul className="mt-2 list-disc space-y-2 pl-5 text-sm text-neutral-800 dark:text-neutral-200">
+            {changelog.changes.map((change, index) => (
+              <li key={`${changelog.version}-${index}`}>{change}</li>
+            ))}
+          </ul>
+        </section>
+      ) : (
+        <section
+          className="settings-entrance my-0!"
+          style={{ animationDelay: "80ms" }}
+        >
+          <h3 className="text-base font-semibold">
+            {t("changelog.notFoundTitle")}
+          </h3>
+          <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+            {t("changelog.notFoundDescription")}
+          </p>
+          {latestVersion ? (
+            <Link
+              to={getChangelogRoute(latestVersion)}
+              className="mt-3 inline-flex rounded border border-primary px-3 py-2 text-sm font-semibold text-primary transition-colors hover:bg-primary/10"
+            >
+              {t("changelog.latestAction", { version: latestVersion })}
+            </Link>
+          ) : null}
+        </section>
+      )}
+
+      <section
+        className="settings-entrance my-0!"
+        style={{ animationDelay: "160ms" }}
+      >
+        <h3 className="text-base font-semibold">
+          {t("changelog.historyTitle")}
+        </h3>
+        <ol className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {VIEW_VERSION_HISTORY.map((entry) => {
+            const isCurrentVersion = entry.version === currentVersion;
+
+            return (
+              <li
+                key={entry.version}
+                className={`flex flex-wrap items-center justify-between gap-3 rounded-md border p-3 ${
+                  isCurrentVersion
+                    ? "border-primary bg-primary/10 dark:border-primary dark:bg-primary/20"
+                    : "border-neutral-200 bg-white dark:border-neutral-700 dark:bg-neutral-900"
+                }`}
+              >
+                <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+                  {t("home.versionUpdateDialog.releaseLabel", {
+                    version: entry.version,
+                    date: formatReleaseDate(entry.releasedAt),
+                  })}
+                </p>
+                <Link
+                  to={getChangelogRoute(entry.version)}
+                  className="text-sm font-semibold text-primary underline decoration-primary/40 underline-offset-2 transition-colors hover:text-primary/80"
+                >
+                  {t("changelog.historyAction")}
+                </Link>
+              </li>
+            );
+          })}
+        </ol>
+      </section>
+    </main>
+  );
+};
+
+export default Changelog;

--- a/src/views/Changelog/Changelog.tsx
+++ b/src/views/Changelog/Changelog.tsx
@@ -125,12 +125,14 @@ const Changelog = (): JSX.Element => {
                     date: formatReleaseDate(entry.releasedAt),
                   })}
                 </p>
-                <Link
-                  to={getChangelogRoute(entry.version)}
-                  className="text-sm font-semibold text-primary underline decoration-primary/40 underline-offset-2 transition-colors hover:text-primary/80"
-                >
-                  {t("changelog.historyAction")}
-                </Link>
+                {isCurrentVersion ? null : (
+                  <Link
+                    to={getChangelogRoute(entry.version)}
+                    className="text-sm font-semibold text-primary underline decoration-primary/40 underline-offset-2 transition-colors hover:text-primary/80"
+                  >
+                    {t("changelog.historyAction")}
+                  </Link>
+                )}
               </li>
             );
           })}

--- a/src/views/Changelog/index.ts
+++ b/src/views/Changelog/index.ts
@@ -1,0 +1,3 @@
+import Changelog from "./Changelog";
+
+export default Changelog;

--- a/src/views/Play/hooks/usePlayController/usePlayController.ts
+++ b/src/views/Play/hooks/usePlayController/usePlayController.ts
@@ -930,6 +930,11 @@ export default function usePlayController(
 
   const changeManualTileSelection = useCallback(
     (enabled: boolean) => {
+      console.log(
+        "Toggling manual tile selection to",
+        enabled,
+        manualTileSelectionRef.current,
+      );
       if (enabled === manualTileSelectionRef.current) {
         return;
       }

--- a/src/views/Play/sections/SettingsDrawer/SettingsDrawer.tsx
+++ b/src/views/Play/sections/SettingsDrawer/SettingsDrawer.tsx
@@ -6,7 +6,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { WORDLE_MODE_IDS, type PlayerDifficulty } from "@domain/wordle";
-import { Button } from "@components";
+import { Button, SwitcherField } from "@components";
 import { useTranslation } from "@i18n";
 import { useFeatureFlags } from "@providers/FeatureFlags";
 import {
@@ -189,30 +189,15 @@ const SettingsDrawer = (): JSX.Element | null => {
               ) : null}
 
               <div className="rounded-lg border border-neutral-200 p-3 dark:border-neutral-700">
-                <div className="flex items-start gap-3">
-                  <input
-                    id={PLAY_SETTINGS_PANEL_MANUAL_TILE_SELECTION_INPUT_ID}
-                    type="checkbox"
-                    checked={player.manualTileSelection}
-                    onChange={(event) =>
-                      changeManualTileSelection(event.target.checked)
-                    }
-                    className="mt-1 h-4 w-4 rounded border-neutral-400 text-blue-600 focus:ring-blue-500"
-                  />
-                  <div>
-                    <label
-                      htmlFor={
-                        PLAY_SETTINGS_PANEL_MANUAL_TILE_SELECTION_INPUT_ID
-                      }
-                      className="profile-field-label"
-                    >
-                      {t("profile.labels.manualTileSelection")}
-                    </label>
-                    <p className="text-xs text-neutral-600 dark:text-neutral-300">
-                      {t("profile.manualTileSelectionDescription")}
-                    </p>
-                  </div>
-                </div>
+                <SwitcherField
+                  id={PLAY_SETTINGS_PANEL_MANUAL_TILE_SELECTION_INPUT_ID}
+                  checked={player.manualTileSelection}
+                  onChange={(event) =>
+                    changeManualTileSelection(event.target.checked)
+                  }
+                  label={t("profile.labels.manualTileSelection")}
+                  description={t("profile.manualTileSelectionDescription")}
+                />
               </div>
             </div>
           </div>

--- a/src/views/Profile/Profile.integration.test.tsx
+++ b/src/views/Profile/Profile.integration.test.tsx
@@ -1,20 +1,24 @@
 import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ScoreClient } from "@api/score";
 import { env } from "@config";
+import { getChangelogRoute } from "@config/routes";
 import { ApiProvider, FeatureFlagsProvider, PlayerProvider } from "@providers";
 import { renderWithQueryClient } from "../../test/utils";
 import Profile from "./Profile";
 
 const renderProfile = () =>
   renderWithQueryClient(
-    <FeatureFlagsProvider>
-      <ApiProvider>
-        <PlayerProvider>
-          <Profile />
-        </PlayerProvider>
-      </ApiProvider>
-    </FeatureFlagsProvider>,
+    <MemoryRouter>
+      <FeatureFlagsProvider>
+        <ApiProvider>
+          <PlayerProvider>
+            <Profile />
+          </PlayerProvider>
+        </ApiProvider>
+      </FeatureFlagsProvider>
+    </MemoryRouter>,
   );
 
 describe("Profile integration", () => {
@@ -113,6 +117,17 @@ describe("Profile integration", () => {
     const main = await screen.findByRole("main");
     expect(main.className).toContain(
       "pb-[calc(env(safe-area-inset-bottom)+6rem)]",
+    );
+  });
+
+  it("renders app version as a changelog link", async () => {
+    renderProfile();
+
+    const versionLink = await screen.findByRole("link", {
+      name: env.appVersion,
+    });
+    expect(versionLink.getAttribute("href")).toBe(
+      getChangelogRoute(env.appVersion),
     );
   });
 

--- a/src/views/Profile/Profile.integration.test.tsx
+++ b/src/views/Profile/Profile.integration.test.tsx
@@ -107,6 +107,15 @@ describe("Profile integration", () => {
     });
   });
 
+  it("keeps bottom safe spacing to avoid footer overlap", async () => {
+    renderProfile();
+
+    const main = await screen.findByRole("main");
+    expect(main.className).toContain(
+      "pb-[calc(env(safe-area-inset-bottom)+6rem)]",
+    );
+  });
+
   it("recovers a profile from the profile view using a recovery code", async () => {
     localStorage.setItem(
       "player",

--- a/src/views/Profile/ProfileContent.tsx
+++ b/src/views/Profile/ProfileContent.tsx
@@ -1,4 +1,6 @@
 import type { JSX } from "react";
+import { Link } from "react-router";
+import { getChangelogRoute } from "@config/routes";
 import { env } from "@config/env";
 import {
   DifficultyChangeDialog,
@@ -17,12 +19,12 @@ const ProfileContent = (): JSX.Element => {
       <div className="settings-entrance" style={{ animationDelay: "0ms" }}>
         <ProfileHeader />
         {env.appVersion && (
-          <span
-            className="text-xs text-gray-500 dark:text-gray-400 m-auto"
-            aria-hidden="true"
+          <Link
+            to={getChangelogRoute(env.appVersion)}
+            className="m-auto text-xs text-gray-500 underline decoration-gray-400/70 underline-offset-2 transition-colors hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
           >
             {env.appVersion}
-          </span>
+          </Link>
         )}
       </div>
       <div className="settings-entrance" style={{ animationDelay: "80ms" }}>

--- a/src/views/Profile/ProfileContent.tsx
+++ b/src/views/Profile/ProfileContent.tsx
@@ -11,7 +11,7 @@ import {
 
 const ProfileContent = (): JSX.Element => {
   return (
-    <main className="page-centered gap-4">
+    <main className="page-centered gap-4 pb-[calc(env(safe-area-inset-bottom)+6rem)]">
       <DifficultyChangeDialog />
       <LanguageDialog />
       <div className="settings-entrance" style={{ animationDelay: "0ms" }}>

--- a/src/views/Profile/sections/SettingsSection/SettingsSection.tsx
+++ b/src/views/Profile/sections/SettingsSection/SettingsSection.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@components";
+import { Button, SwitcherField } from "@components";
 import type { ThemePreference } from "@hooks/useThemePreference";
 import { useTranslation } from "@i18n";
 import { useFeatureFlags } from "@providers/FeatureFlags";
@@ -69,76 +69,37 @@ const SettingsSection = () => {
         </Button>
       </div>
       <div id="end-dialogs" className="mt-4 max-w-xl">
-        <div className="flex items-start gap-3">
-          <input
-            id={PROFILE_END_OF_GAME_DIALOGS_INPUT_ID}
-            type="checkbox"
-            checked={showEndOfGameDialogs}
-            onChange={(event) =>
-              changeShowEndOfGameDialogs(event.target.checked)
-            }
-            className="mt-1 h-4 w-4 rounded border-neutral-400 text-blue-600 focus:ring-blue-500"
-          />
-          <div>
-            <label
-              htmlFor={PROFILE_END_OF_GAME_DIALOGS_INPUT_ID}
-              className="profile-field-label"
-            >
-              {t("profile.labels.endOfGameDialogs")}
-            </label>
-            <p className="text-xs text-neutral-600 dark:text-neutral-300">
-              {t("profile.endOfGameDialogsDescription")}
-            </p>
-          </div>
-        </div>
+        <SwitcherField
+          id={PROFILE_END_OF_GAME_DIALOGS_INPUT_ID}
+          checked={showEndOfGameDialogs}
+          onChange={(event) =>
+            changeShowEndOfGameDialogs(event.target.checked)
+          }
+          label={t("profile.labels.endOfGameDialogs")}
+          description={t("profile.endOfGameDialogsDescription")}
+        />
       </div>
       {soundFeatureEnabled ? (
         <div id="sound-enabled" className="mt-4 max-w-xl">
-          <div className="flex items-start gap-3">
-            <input
-              id={PROFILE_SOUND_ENABLED_INPUT_ID}
-              type="checkbox"
-              checked={soundEnabled}
-              onChange={(event) => changeSoundEnabled(event.target.checked)}
-              className="mt-1 h-4 w-4 rounded border-neutral-400 text-blue-600 focus:ring-blue-500"
-            />
-            <div>
-              <label
-                htmlFor={PROFILE_SOUND_ENABLED_INPUT_ID}
-                className="profile-field-label"
-              >
-                {t("profile.labels.sound")}
-              </label>
-              <p className="text-xs text-neutral-600 dark:text-neutral-300">
-                {t("profile.soundEnabledDescription")}
-              </p>
-            </div>
-          </div>
+          <SwitcherField
+            id={PROFILE_SOUND_ENABLED_INPUT_ID}
+            checked={soundEnabled}
+            onChange={(event) => changeSoundEnabled(event.target.checked)}
+            label={t("profile.labels.sound")}
+            description={t("profile.soundEnabledDescription")}
+          />
         </div>
       ) : null}
       <div id="manual-tile-selection" className="mt-4 max-w-xl">
-        <div className="flex items-start gap-3">
-          <input
-            id={PROFILE_MANUAL_TILE_SELECTION_INPUT_ID}
-            type="checkbox"
-            checked={manualTileSelection}
-            onChange={(event) =>
-              changeManualTileSelection(event.target.checked)
-            }
-            className="mt-1 h-4 w-4 rounded border-neutral-400 text-blue-600 focus:ring-blue-500"
-          />
-          <div>
-            <label
-              htmlFor={PROFILE_MANUAL_TILE_SELECTION_INPUT_ID}
-              className="profile-field-label"
-            >
-              {t("profile.labels.manualTileSelection")}
-            </label>
-            <p className="text-xs text-neutral-600 dark:text-neutral-300">
-              {t("profile.manualTileSelectionDescription")}
-            </p>
-          </div>
-        </div>
+        <SwitcherField
+          id={PROFILE_MANUAL_TILE_SELECTION_INPUT_ID}
+          checked={manualTileSelection}
+          onChange={(event) =>
+            changeManualTileSelection(event.target.checked)
+          }
+          label={t("profile.labels.manualTileSelection")}
+          description={t("profile.manualTileSelectionDescription")}
+        />
       </div>
       <DifficultySection />
     </section>

--- a/src/views/Profile/sections/SettingsSection/SettingsSection.tsx
+++ b/src/views/Profile/sections/SettingsSection/SettingsSection.tsx
@@ -72,9 +72,7 @@ const SettingsSection = () => {
         <SwitcherField
           id={PROFILE_END_OF_GAME_DIALOGS_INPUT_ID}
           checked={showEndOfGameDialogs}
-          onChange={(event) =>
-            changeShowEndOfGameDialogs(event.target.checked)
-          }
+          onChange={(event) => changeShowEndOfGameDialogs(event.target.checked)}
           label={t("profile.labels.endOfGameDialogs")}
           description={t("profile.endOfGameDialogsDescription")}
         />
@@ -94,9 +92,7 @@ const SettingsSection = () => {
         <SwitcherField
           id={PROFILE_MANUAL_TILE_SELECTION_INPUT_ID}
           checked={manualTileSelection}
-          onChange={(event) =>
-            changeManualTileSelection(event.target.checked)
-          }
+          onChange={(event) => changeManualTileSelection(event.target.checked)}
           label={t("profile.labels.manualTileSelection")}
           description={t("profile.manualTileSelectionDescription")}
         />

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -8,6 +8,7 @@ import GameModes from "./GameModes";
 import Lighting from "./GameModes/Lightning";
 import Zen from "./GameModes/Zen";
 import Daily from "./GameModes/Daily";
+import Changelog from "./Changelog";
 export {
   Home,
   Help,
@@ -19,4 +20,5 @@ export {
   Lighting,
   Zen,
   Daily,
+  Changelog,
 };


### PR DESCRIPTION
### Branch `0.0.21`

- Bumped package version to `0.0.21`.
- Added a dedicated changelog page route (`/changelog/:version`) and wired it into app routing.
- Moved changelog content to a typed JSON source (`src/layouts/View/changelog.json`) with entries keyed by `version` and localized by `language` (`en`/`es`), plus helper resolvers/history derivation in `src/layouts/View/changelog.ts`.
- Simplified the version-update dialog flow: release announcement copy, linkable version history, and direct CTA to open the current changelog page.
- Added a full changelog view with release metadata, per-version navigation links, not-found fallback, and a two-column version-history grid.
- Introduced reusable `Switcher` and `SwitcherField` components and replaced checkbox toggles in Profile Settings and Play Settings Drawer with the new switch UI.
- Hardened Switcher typing/accessibility by explicitly supporting common input props and ARIA attributes through the component API.
- Fixed manual tile selection editing so letter insertion in manual mode now advances the active tile index after writing.
- Fixed manual-mode backspace behavior so it clears the selected tile and moves the cursor left, allowing consecutive deletions.
- Fixed selected-index deletion behavior so remaining letters no longer shift left unexpectedly (`removeLetterAt` now clears in-place and trims trailing blanks).
- Fixed Profile page bottom spacing to avoid footer overlap by adding safe-area aware bottom padding.